### PR TITLE
[WIP] Traduction FR PHV

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -6,20 +6,20 @@
       "help": "La valeur de l’attribut accesskey doit être unique"
     },
     "area-alt": {
-      "description": "S’assure que que les éléments <area> d’une image réactive ont un texte alternatif",
+      "description": "S’assure que les éléments <area> d’une image réactive ont une alternative textuelle",
       "help": "Les éléments <area> actifs doivent avoir un texte alternatif"
     },
     "aria-allowed-attr": {
-      "description": "S’assure que que les attributs ARIA sont autorisés pour le rôle d’un élément",
+      "description": "S’assure que les attributs ARIA sont autorisés pour le rôle d’un élément",
       "help": "Les éléments doivent seulement utiliser les attributs ARIA autorisés"
     },
     "aria-dpub-role-fallback": {
-      "description": "S’assure que que les rôles DPUB non supportés ne sont utilisés que sur des éléments avec des rôles implicites",
+      "description": "S’assure que les rôles DPUB non supportés ne sont utilisés que sur des éléments avec des rôles implicites",
       "help": "Les rôles DPUB non supportés doivent être utilisés sur des éléments avec des rôles implicites"
     },
     "aria-hidden-body": {
-      "description": "S’assure que aria-hidden='true' n’est pas présent sur le corps du document (élément body)",
-      "help": "aria-hidden='true' ne doit pas être présent sur body"
+      "description": "S’assure que aria-hidden=\"true\" n’est pas présent sur le corps du document (élément body)",
+      "help": "aria-hidden=\"true\" ne doit pas être présent sur body"
     },
     "aria-required-attr": {
       "description": "S’assure que les éléments avec des rôles ARIA ont les attributs ARIA requis",
@@ -74,7 +74,7 @@
       "help": "Les éléments <dl> ne doivent contenir directement que des groupes d’élements <dt> et <dd> correctement ordonnés, ou des éléments <script> ou <template>"
     },
     "dlitem": {
-      "description": "S’assure que les éléments <dt> et <dd> elements sont contenus dans un élément <dl>",
+      "description": "S’assure que les éléments <dt> et <dd> sont contenus dans un élément <dl>",
       "help": "Les éléments <dt> et <dd> doivent être contenus dans un élément <dl>"
     },
     "document-title": {


### PR DESCRIPTION
- répétition "que que" et "éléments (…) elements"
- "alternative textuelle" et pas "texte alternatif" (pour cohérence avec la traduction FR des WCAG et RGAA 3)
- guillemets (échappés) pour valeurs
